### PR TITLE
PaddleOCR retrain

### DIFF
--- a/ppocr/data/simple_dataset.py
+++ b/ppocr/data/simple_dataset.py
@@ -32,7 +32,10 @@ class SimpleDataSet(Dataset):
         dataset_config = config[mode]["dataset"]
         loader_config = config[mode]["loader"]
 
-        self.delimiter = dataset_config.get("delimiter", "\t")
+        # !!! will be fixed in dataset
+        # self.delimiter = dataset_config.get("delimiter", "\t")
+        self.delimiter = dataset_config.get("delimiter", " ")
+        
         label_file_list = dataset_config.pop("label_file_list")
         data_source_num = len(label_file_list)
         ratio_list = dataset_config.get("ratio_list", 1.0)

--- a/tools/_export_model.bat
+++ b/tools/_export_model.bat
@@ -1,0 +1,7 @@
+@echo off
+
+REM Execute export
+python export_model.py -c ../configs/rec/en_PP-OCRv4_rec_train/en_PP-OCRv4_rec.yml -o Global.pretrained_model=output/rec_ppocr_v4/latest -o Global.save_inference_dir=./inference/rec_ppocr_v4
+
+REM Pause the console to keep it open after execution
+pause

--- a/tools/_inference_rec.bat
+++ b/tools/_inference_rec.bat
@@ -1,0 +1,7 @@
+@echo off
+
+REM Execute export
+python export_model.py -c ../configs/rec/en_PP-OCRv4_rec_train/en_PP-OCRv4_rec.yml -o Global.pretrained_model=output/rec_ppocr_v4/latest Global.infer_img=./train_data/dataset.20250113_143943/99926b5b173440e28cba9b6dd4caaafc_478_(63739-434.bin.png Global.use_gpu=False
+
+REM Pause the console to keep it open after execution
+pause

--- a/tools/_train.bat
+++ b/tools/_train.bat
@@ -1,0 +1,7 @@
+@echo off
+
+REM Execute training
+python train.py -c ../configs/rec/en_PP-OCRv4_rec_train/en_PP-OCRv4_rec.yml -o Global.checkpoints=../configs/rec/en_PP-OCRv4_rec_train/best_accuracy
+
+REM Pause the console to keep it open after execution
+pause


### PR DESCRIPTION
This project is Fork from project paddlepaddle: https://github.com/PaddlePaddle/PaddleOCR

Step to start retrian paddle:
- Clone PaddleOCR project from our mazoea github
- Create conda enviroment and install all requirements needed for running paddle train
- install requirements and either cpu paddle or paddlepaddle-gpu==2.5.0 and make sure you have CUDA v11.2 (cudnn64_8.dll)
- download english model. For example from here: https://github.com/PaddlePaddle/PaddleOCR/blob/release/2.7/doc/doc_ch/models_list.md
- put it in config, where other models are

- Create folder 'train_data' in tools and add there your data
- data: 
train_list.txt and val_list.txt with lines like: 'test.png AHOJ'
images: test.png

- configure downloaded yml eng model:
set use_gpu to False, if you do not want to train on gpu
set correct dict path for en_dict.txt (like: character_dict_path: ../ppocr/utils/en_dict.txt)

- To start training, run _train.bat or:
```
python train.py -c ../configs/rec/en_PP-OCRv4_rec_train/en_PP-OCRv4_rec.yml -o
Global.checkpoints=../configs/rec/en_PP-OCRv4_rec_train/best_accuracy
```
output folder will be created and there will be all files from training (pdopt, pdparams, states and info)


- To export model, run _export_model.bat or:
```
python export_model.py 
-c ../configs/rec/en_PP-OCRv4_rec_train/en_PP-OCRv4_rec.yml
-o Global.pretrained_model=output/rec_ppocr_v4/latest
-o Global.save_inference_dir=./inference/rec_ppocr_v4
```
where en_PP-OCRv4_rec.yml is downloaded pre-trained model, latest is best one out of files from training and inference/rec_ppocr_v4 is location for inference model.


- To run inference on image, run _inference_rec.bat or:
```
python infer_rec.py 
-c
../configs/rec/en_PP-OCRv4_rec_train/en_PP-OCRv4_rec.yml
-o
Global.pretrained_model=output/rec_ppocr_v4/latest
Global.infer_img=./train_data/dataset.20250113_143943/99926b5b173440e28cba9b6dd4caaafc_478_(63739-434.bin.png
Global.use_gpu=False
```
