### PR TITLE
Wire optional rotator-AUC eval pass from maz

### DIFF
--- a/tools/eval.py
+++ b/tools/eval.py
@@ -35,6 +35,18 @@ from ppocr.metrics import build_metric
 from ppocr.utils.save_load import load_model
 import tools.program as program
 
+# Optional rotator-AUC pass; all logic lives in maz.  Import guarded so a
+# broken/missing maz module never masks a successful acc eval.
+try:
+    from maz.tools.rotator_eval_pass import run_rotator_eval
+    _ROTATOR_AVAILABLE = True
+except Exception as _rot_import_err:
+    print(
+        f"WARNING: rotator pass unavailable, will be skipped: "
+        f"{type(_rot_import_err).__name__}: {_rot_import_err}"
+    )
+    _ROTATOR_AVAILABLE = False
+
 
 def write_eval_diffs(metric: dict, config: dict, checkpoint: str | None = None) -> None:
     """Write ``eval.diffs.*.json`` for the current evaluation run.
@@ -231,6 +243,13 @@ def main():
     for k, v in metric.items():
         msg = "{}:{}".format(k, v)
         logger.info(msg) if k != "acc" else logger.critical(msg)
+
+    # No-op unless Eval.rotator.enabled is set.  All logic lives in maz.
+    # Guarded by import success so we don't try to call a missing function.
+    if _ROTATOR_AVAILABLE:
+        model.eval()
+        run_rotator_eval(config, lambda x: model(x), valid_dataloader,
+                         post_process_class, config.get("checkpoints"), logger)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- Adds 12 lines to ``tools/eval.py`` to surface the new rotator-AUC eval pass from maz (mazoea/te-train-pp#4).
- Import is guarded with a ``_ROTATOR_AVAILABLE`` sentinel — if maz is missing / broken / not yet pulled to the version that contains ``rotator_eval_pass``, a single ``WARNING`` line is printed at startup and the regular acc eval continues unchanged.
- Call site in ``main()`` is guarded by ``if _ROTATOR_AVAILABLE`` so a failed import never even attempts to call a missing function.

## Why

The te-server rotator (``input_classifier/_rotation_ts_ocr.py`` in te-server) decides page orientation by comparing OCR confidences at 0° vs 180°. Per-page success therefore depends on the OCR model producing higher confidence on correctly-oriented input. Until now nothing in the eval pipeline measured that property, so the rotator could silently regress with each new checkpoint.

When a YAML enables ``Eval.rotator.enabled`` (currently only ``eval.IBedits.yml`` in maz), ``run_rotator_eval`` runs each batch twice — original + ``paddle.flip(images, axis=[2, 3])`` — and reports AUC + sign_rate alongside the existing ``acc:`` line. Pure no-op when the flag is off; zero cost on the 11 other shipped configs.

## Behaviour matrix

| maz state | ``Eval.rotator.enabled`` | Result |
|---|---|---|
| present + correct version | ``true`` | AUC + sign_rate logged after acc, JSON dumped to ``EVAL_OUTPUT_DIR`` |
| present + correct version | ``false`` | Regular acc eval only (rotator entry point is a no-op) |
| missing / broken / outdated | any | One WARNING line at startup, regular acc eval only — no exception, no behavioural change |

## Diff

```python
+# Optional rotator-AUC pass; all logic lives in maz.  Import guarded so a
+# broken/missing maz module never masks a successful acc eval.
+try:
+    from maz.tools.rotator_eval_pass import run_rotator_eval
+    _ROTATOR_AVAILABLE = True
+except Exception as _rot_import_err:
+    print(
+        f\"WARNING: rotator pass unavailable, will be skipped: \"
+        f\"{type(_rot_import_err).__name__}: {_rot_import_err}\"
+    )
+    _ROTATOR_AVAILABLE = False
```

```python
     # No-op unless Eval.rotator.enabled is set.  All logic lives in maz.
+    # Guarded by import success so we don't try to call a missing function.
+    if _ROTATOR_AVAILABLE:
+        model.eval()
+        run_rotator_eval(config, lambda x: model(x), valid_dataloader,
+                         post_process_class, config.get(\"checkpoints\"), logger)
```

## Test plan

- [x] Syntax check of patched ``tools/eval.py``
- [x] mazoea/te-train-pp#4 has 246 unit tests passing for the maz side
- [ ] End-to-end smoke: run ``eval.bat`` against a real checkpoint with the maz PR pulled in, confirm AUC/SR populated for IBedits
- [ ] End-to-end smoke: temporarily delete ``maz/tools/rotator_eval_pass.py``, confirm one WARNING line + regular acc eval still works

## Dependencies

Depends on mazoea/te-train-pp#4 being merged (or the maz submodule pointed at ``feat/rotator-auc-eval``) for ``run_rotator_eval`` to actually be available. Until then the import-failure path will trigger the WARNING and the rotator pass will be skipped — by design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)