### PR TITLE
ci: run pre-commit directly instead of pre-commit/action (Node 20)

### DIFF
--- a/.github/workflows/codestyle.yml
+++ b/.github/workflows/codestyle.yml
@@ -31,6 +31,15 @@ jobs:
         python -m pip install --upgrade pip
         pip install "clang-format==13.0.0"
 
-    - uses: pre-commit/action@v3.0.1
+    # pre-commit/action@v3.0.1 is unmaintained and bundles actions/cache@v4
+    # (Node 20). Run pre-commit directly with a Node 24 cache action instead.
+    - name: Cache pre-commit
+      uses: actions/cache@v5
       with:
-        extra_args: '--all-files'
+        path: ~/.cache/pre-commit
+        key: pre-commit-${{ hashFiles('.pre-commit-config.yaml') }}
+
+    - name: Run pre-commit
+      run: |
+        python -m pip install pre-commit
+        pre-commit run --show-diff-on-failure --color=always --all-files


### PR DESCRIPTION
## What

Replaces `pre-commit/action@v3.0.1` in `codestyle.yml` with a direct `pre-commit` invocation + `actions/cache@v5`.

## Why

`pre-commit/action@v3.0.1` is a `composite` action whose `action.yml` does `uses: actions/cache@v4` — which runs on the deprecated **Node 20** runtime (force-disabled by GitHub on **June 2nd 2026**). So even though `codestyle.yml` references only Node-24 actions directly, this job pulls in a Node-20 one transitively.

`pre-commit/action` v3.0.1 is its last release and is effectively unmaintained (its `main` still pins `cache@v4`), so there's no version bump that fixes it — the action has to be replaced.

## Behaviour

Unchanged. The `extra_args: '--all-files'` is preserved as an explicit `--all-files` flag. Caching is preserved via `actions/cache@v5` on `~/.cache/pre-commit`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)